### PR TITLE
fix: Ignore authors with a None value; and: Handle files that have no cover image

### DIFF
--- a/ebookmeta/epub2.py
+++ b/ebookmeta/epub2.py
@@ -126,7 +126,11 @@ class Epub2:
         cover_href = self.get_cover_href(self.get_cover_id())
         if cover_href is not None:
             z = ZipFile(self.file)
-            cover_data = z.read(self.content_root + cover_href)
+            try:
+                cover_data = z.read(self.content_root + cover_href)
+            except KeyError:
+                # Cover image not found
+                pass
             z.close()
 
         return cover_data

--- a/ebookmeta/epub2.py
+++ b/ebookmeta/epub2.py
@@ -96,6 +96,8 @@ class Epub2:
         metadata.author = []
         metadata.author_sort = []
         for n in node_list:
+            if n.text is None:
+                continue
             metadata.author.append(n.text)
             metadata.author_sort.append(person_sort_name(n.text))
         metadata.series = xstr(self.get('opf:metadata/opf:meta[@name="calibre:series"]/@content'))

--- a/ebookmeta/epub3.py
+++ b/ebookmeta/epub3.py
@@ -101,6 +101,8 @@ class Epub3:
         for e in creator_list:
             value = self.get_element_refines(self.get_element_id(e), property='role')
             if value == 'aut' or not value:
+                if e.text is None:
+                    continue
                 metadata.author.append(e.text)
                 metadata.author_sort.append(person_sort_name(e.text))
             elif value == 'trl':

--- a/ebookmeta/epub3.py
+++ b/ebookmeta/epub3.py
@@ -140,7 +140,11 @@ class Epub3:
         cover_href = self.get_cover_href(self.get_cover_id())
         if cover_href is not None:
             z = ZipFile(self.file)
-            cover_data = z.read(self.content_root + cover_href)
+            try:
+                cover_data = z.read(self.content_root + cover_href)
+            except KeyError:
+                # Cover image not found
+                pass
             z.close()
 
         return cover_data

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ebookmeta',
-    version='0.11.3',
+    version='0.11.4',
     author='Dmitrii Korpushov',
     author_email='dnkorpushov@gmail.com',
     packages=['ebookmeta'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='ebookmeta',
-    version='0.11.2',
+    version='0.11.3',
     author='Dmitrii Korpushov',
     author_email='dnkorpushov@gmail.com',
     packages=['ebookmeta'],


### PR DESCRIPTION
This pull request includes two fixes:
* Ignore authors with a None value
    * which would otherwise raise an exception when attempting to .split() the author name
* Handle files that have a cover image href but no detected image at that href
    * which would otherwise raise an exception when attempting to construct a ZipInfo object for the cover image

They're the result of my own testing, where I encountered epub files that resulted in the aforementioned exceptions.

Let me know if you want to break this up into separate pull requests, etc., or if you have any questions at all. Thanks!